### PR TITLE
✨feat :  Estate 관련 기능 구현

### DIFF
--- a/src/main/java/com/proppay/platform/PropPayApplication.java
+++ b/src/main/java/com/proppay/platform/PropPayApplication.java
@@ -2,8 +2,12 @@ package com.proppay.platform;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 @SpringBootApplication
+@EnableJpaRepositories(basePackages = "com.proppay.platform.pay.adapter.out.jpa")
+@EnableMongoRepositories(basePackages = "com.proppay.platform.pay.adapter.out.mongo")
 public class PropPayApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/proppay/platform/core/config/mongo/MongoConfig.java
+++ b/src/main/java/com/proppay/platform/core/config/mongo/MongoConfig.java
@@ -7,14 +7,10 @@ import com.mongodb.client.MongoClients;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.mongodb.MongoDatabaseFactory;
-import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
-@EnableTransactionManagement
 public class MongoConfig extends AbstractMongoClientConfiguration {
 
     @Value("${spring.data.mongodb.uri}")
@@ -22,11 +18,6 @@ public class MongoConfig extends AbstractMongoClientConfiguration {
 
     @Value("${spring.data.mongodb.database}")
     private String databaseName;
-
-    @Bean
-    public MongoTransactionManager transactionManager(MongoDatabaseFactory dbFactory) {
-        return new MongoTransactionManager(dbFactory);
-    }
 
     @Bean
     public MongoTemplate mongoTemplate() {
@@ -48,3 +39,4 @@ public class MongoConfig extends AbstractMongoClientConfiguration {
         return databaseName;
     }
 }
+

--- a/src/main/java/com/proppay/platform/core/config/mongo/MongoConfig.java
+++ b/src/main/java/com/proppay/platform/core/config/mongo/MongoConfig.java
@@ -1,0 +1,50 @@
+package com.proppay.platform.core.config.mongo;
+
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoTransactionManager;
+import org.springframework.data.mongodb.config.AbstractMongoClientConfiguration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableTransactionManagement
+public class MongoConfig extends AbstractMongoClientConfiguration {
+
+    @Value("${spring.data.mongodb.uri}")
+    private String connectionString;
+
+    @Value("${spring.data.mongodb.database}")
+    private String databaseName;
+
+    @Bean
+    public MongoTransactionManager transactionManager(MongoDatabaseFactory dbFactory) {
+        return new MongoTransactionManager(dbFactory);
+    }
+
+    @Bean
+    public MongoTemplate mongoTemplate() {
+        return new MongoTemplate(mongoClient(), databaseName);
+    }
+
+    @Override
+    public MongoClient mongoClient() {
+        ConnectionString connectionString = new ConnectionString(this.connectionString);
+        MongoClientSettings mongoClientSettings = MongoClientSettings.builder()
+                .applyConnectionString(connectionString)
+                .build();
+
+        return MongoClients.create(mongoClientSettings);
+    }
+
+    @Override
+    protected String getDatabaseName() {
+        return databaseName;
+    }
+}

--- a/src/main/java/com/proppay/platform/pay/adapter/in/web/EstateApi.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/in/web/EstateApi.java
@@ -5,6 +5,7 @@ import com.proppay.platform.core.dto.PageRequest;
 import com.proppay.platform.core.dto.PageResponse;
 import com.proppay.platform.pay.adapter.in.web.dto.EstateDetailResponse;
 import com.proppay.platform.pay.adapter.in.web.dto.EstateListResponse;
+import com.proppay.platform.pay.adapter.in.web.dto.EstateLocationRequest;
 import com.proppay.platform.pay.application.in.estate.GetEstateUseCase;
 import com.proppay.platform.pay.domain.estate.Estate;
 import jakarta.persistence.EntityNotFoundException;
@@ -63,4 +64,12 @@ public class EstateApi {
         return ApiResponse.ok(new PageResponse<>(dtolist, pageRequest, result.getTotalElements()));
     }
 
+    // 특정 좌표 근처의 아파트 목록 조회
+    @GetMapping("/list/location")
+    public ApiResponse<List<EstateListResponse>> getEstateByLocation(@RequestBody EstateLocationRequest request) {
+
+        List<Estate> list = getService.loadEstatesNearBy(request.getLongitude(), request.getLatitude(), request.getRadius());
+        return ApiResponse.ok(EstateListResponse.from(list));
+
+    }
 }

--- a/src/main/java/com/proppay/platform/pay/adapter/in/web/EstateApi.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/in/web/EstateApi.java
@@ -1,0 +1,66 @@
+package com.proppay.platform.pay.adapter.in.web;
+
+import com.proppay.platform.core.api.ApiResponse;
+import com.proppay.platform.core.dto.PageRequest;
+import com.proppay.platform.core.dto.PageResponse;
+import com.proppay.platform.pay.adapter.in.web.dto.EstateDetailResponse;
+import com.proppay.platform.pay.adapter.in.web.dto.EstateListResponse;
+import com.proppay.platform.pay.application.in.estate.GetEstateUseCase;
+import com.proppay.platform.pay.domain.estate.Estate;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/estate")
+@RequiredArgsConstructor
+public class EstateApi {
+
+    private final GetEstateUseCase getService;
+
+    // 상세 정보 조회
+    @GetMapping
+    public ApiResponse<EstateDetailResponse> getEstate(
+            @RequestParam(value = "code", required = false) String code,
+            @RequestParam(value = "name", required = false) String name) {
+
+        Estate estate;
+
+        if (code != null) {
+            estate = getService.loadEstateByCode(code)
+                    .orElseThrow(() -> new EntityNotFoundException("해당하는 아파트가 존재하지 않습니다."));
+        } else if (name != null) {
+            estate = getService.loadEstateByName(name)
+                    .orElseThrow(() -> new EntityNotFoundException("해당하는 아파트가 존재하지 않습니다."));
+        } else {
+            throw new IllegalArgumentException("최소 하나 이상의 요청 파라미터가 필요합니다.");
+        }
+
+        return ApiResponse.created(EstateDetailResponse.from(estate));
+    }
+
+    // 특정 지역 아파트 목록 조회
+    @GetMapping("/list")
+    public ApiResponse<PageResponse<EstateListResponse>> getEstateByRegion(
+            @RequestParam(value = "region") String region,
+            PageRequest pageRequest) {
+
+        Pageable pageable = org.springframework.data.domain.PageRequest.of(
+                pageRequest.getPage() - 1,
+                pageRequest.getSize(),
+                Sort.by(Sort.Direction.DESC, "id")
+        );
+
+        Page<Estate> result = getService.loadEstatesByRegion(region, pageable);
+
+        List<EstateListResponse> dtolist = EstateListResponse.from(result.getContent());
+
+        return ApiResponse.ok(new PageResponse<>(dtolist, pageRequest, result.getTotalElements()));
+    }
+
+}

--- a/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/EstateAreaResponse.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/EstateAreaResponse.java
@@ -1,0 +1,25 @@
+package com.proppay.platform.pay.adapter.in.web.dto;
+
+import com.proppay.platform.pay.domain.estate.Estate;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class EstateAreaResponse {
+
+    // 아파트 면적 (제곱미터 단위)
+    private String area135sqm; // 135㎡ 타입 면적
+    private String area136sqm; // 136㎡ 타입 면적
+    private String area60sqm;  // 60㎡ 타입 면적
+    private String area85sqm;  // 85㎡ 타입 면적
+
+    public static EstateAreaResponse from(Estate estate) {
+        return EstateAreaResponse.builder()
+                .area135sqm(estate.getKaptMparea_135())
+                .area136sqm(estate.getKaptMparea_136())
+                .area60sqm(estate.getKaptMparea_60())
+                .area85sqm(estate.getKaptMparea_85())
+                .build();
+    }
+}

--- a/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/EstateDetailResponse.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/EstateDetailResponse.java
@@ -1,0 +1,37 @@
+package com.proppay.platform.pay.adapter.in.web.dto;
+
+import com.proppay.platform.pay.domain.estate.Estate;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class EstateDetailResponse {
+
+    // 아파트 기본 정보
+    private String complexCode;  // 아파트 단지 코드
+    private String complexName;  // 아파트 단지명
+    private String address;      // 주소
+
+    // 좌표
+    private EstateLocationResponse location;
+
+    // 가격 정보 (제곱미터당 가격)
+    private String pricePerSqm;
+
+    // 면적 및 편의시설 정보
+    private EstateAreaResponse area;
+    private EstateFacilityResponse facility;
+
+    public static EstateDetailResponse from(Estate estate) {
+        return EstateDetailResponse.builder()
+                .complexCode(estate.getKaptCode())
+                .complexName(estate.getKaptName())
+                .address(estate.getKaptAddr())
+                .location(EstateLocationResponse.from(estate))
+                .pricePerSqm(estate.getPricePerSquareMeter())
+                .area(EstateAreaResponse.from(estate))
+                .facility(EstateFacilityResponse.from(estate))
+                .build();
+    }
+}

--- a/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/EstateFacilityResponse.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/EstateFacilityResponse.java
@@ -1,0 +1,70 @@
+package com.proppay.platform.pay.adapter.in.web.dto;
+
+import com.proppay.platform.pay.domain.estate.Estate;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class EstateFacilityResponse {
+
+    // 주변 시설 정보
+    private String publicOffices; // 관공서, 행정기관
+    private String hospitals; // 병원
+    private String shoppingCenters; // 쇼핑몰, 백화점
+    private String parks; // 공원
+
+    // 교육 시설
+    private String elementarySchool;
+    private String middleSchool;
+    private String highSchool;
+
+    // 주거 편의 정보
+    private String totalHouseholds; // 총 세대수
+    private String householdUnits; // 세대 구성 수
+
+    // 교통 정보
+    private String busCommuteTime; // 버스 이동 시간
+    private String subwayCommuteTime; // 지하철 이동 시간
+    private String subwayLine; // 지하철 노선
+    private String subwayStation; // 지하철역
+
+    // 복지 시설
+    private String welfareFacilities; // 노인정, 놀이터 등
+
+    public static EstateFacilityResponse from(Estate estate) {
+        return EstateFacilityResponse.builder()
+                .publicOffices(extractFacility(estate.getConvenientFacility(), "관공서"))
+                .hospitals(extractFacility(estate.getConvenientFacility(), "병원"))
+                .shoppingCenters(extractFacility(estate.getConvenientFacility(), "백화점"))
+                .parks(extractFacility(estate.getConvenientFacility(), "공원"))
+
+                .elementarySchool(extractFacility(estate.getEducationFacility(), "초등학교"))
+                .middleSchool(extractFacility(estate.getEducationFacility(), "중학교"))
+                .highSchool(extractFacility(estate.getEducationFacility(), "고등학교"))
+
+                .totalHouseholds(estate.getKaptdPcnt())
+                .householdUnits(estate.getKaptdPcntu())
+
+                .busCommuteTime(estate.getKaptdWtimebus())
+                .subwayCommuteTime(estate.getKaptdWtimesub())
+                .subwayLine(estate.getSubwayLine())
+                .subwayStation(estate.getSubwayStation())
+
+                .welfareFacilities(estate.getWelfareFacility())
+                .build();
+    }
+
+    // 특정 유형의 시설을 추출하는 유틸리티 메서드
+    private static String extractFacility(String facilities, String type) {
+        if (facilities == null || !facilities.contains(type)) {
+            return null;
+        }
+        for (String facility : facilities.split(" ")) {
+            if (facility.startsWith(type)) {
+                return facility;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/EstateListResponse.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/EstateListResponse.java
@@ -1,0 +1,35 @@
+package com.proppay.platform.pay.adapter.in.web.dto;
+
+import com.proppay.platform.pay.domain.estate.Estate;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.*;
+
+@Data
+@Builder
+public class EstateListResponse {
+
+    // 아파트 기본 정보
+    private String complexCode;  // 아파트 단지 코드
+    private String complexName;  // 아파트 단지명
+    private String address;      // 주소
+
+    // 좌표
+    private EstateLocationResponse location;
+
+
+    public static EstateListResponse from(Estate estate) {
+        return EstateListResponse.builder()
+                .complexCode(estate.getKaptCode())
+                .complexName(estate.getKaptName())
+                .address(estate.getKaptAddr())
+                .location(EstateLocationResponse.from(estate))
+                .build();
+    }
+
+    public static List<EstateListResponse> from(List<Estate> estates) {
+        return estates.stream().map(EstateListResponse::from).toList();
+    }
+
+}

--- a/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/EstateLocationRequest.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/EstateLocationRequest.java
@@ -1,0 +1,12 @@
+package com.proppay.platform.pay.adapter.in.web.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class EstateLocationRequest {
+    private double longitude; // 경도
+    private double latitude;  // 위도
+    private double radius;    // 검색 반경 (km 단위)
+}

--- a/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/EstateLocationResponse.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/EstateLocationResponse.java
@@ -1,0 +1,22 @@
+package com.proppay.platform.pay.adapter.in.web.dto;
+
+import com.proppay.platform.pay.domain.estate.Estate;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class EstateLocationResponse {
+
+    // 좌표
+    private double latitude;     // 위도
+    private double longitude;    // 경도
+
+    public static EstateLocationResponse from(Estate estate) {
+        return EstateLocationResponse.builder()
+                .latitude(estate.getLocation().getLatitude())
+                .longitude(estate.getLocation().getLongitude())
+                .build();
+    }
+
+}

--- a/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/PropertyConditionRequest.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/PropertyConditionRequest.java
@@ -3,7 +3,7 @@ package com.proppay.platform.pay.adapter.in.web.dto;
 import lombok.Data;
 
 @Data
-public class ConditionRequest {
+public class PropertyConditionRequest {
 
     // 지역
     private String city; // 도시

--- a/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/PropertyListResponse.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/PropertyListResponse.java
@@ -22,7 +22,7 @@ public class PropertyListResponse {
     public static PropertyListResponse from(Property property) {
         return PropertyListResponse.builder()
                 .id(property.getId())
-                .title(property.getSnippet().getTitle())
+                .title(property.getSnippet().getAptName())
                 .type(property.getType())
                 .price(property.getPrice())
                 .city(property.getAddress().getCity())

--- a/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/PropertyRequest.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/PropertyRequest.java
@@ -8,9 +8,6 @@ import lombok.Data;
 public class PropertyRequest {
 
     // 위치 정보
-    @NotBlank(message = "도로명 주소는 필수입니다.")
-    private String streetAddress;
-
     @NotBlank(message = "상세 주소는 필수입니다.")
     private String detailAddress;
 
@@ -25,12 +22,12 @@ public class PropertyRequest {
     @Min(value = 0, message = "가격은 0 이상이어야 합니다.")
     private long price;
 
+    @NotBlank(message = "아파트 코드은 필수입니다.")
+    private String aptCode;
+
     // 매물의 특징
     @NotNull(message = "매물 유형은 필수입니다.")
     private PropertyType type;
-
-    @NotBlank(message = "매물 이름은 필수입니다.")
-    private String title;
 
     @NotBlank(message = "매물 설명은 필수입니다.")
     private String description;

--- a/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/PropertySnippetResponse.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/in/web/dto/PropertySnippetResponse.java
@@ -8,14 +8,11 @@ import lombok.Data;
 @Data
 @Builder
 public class PropertySnippetResponse {
-    private String title;
-    private String description;
-
+    private String complexName;
     private String streetAddress;
+
     private String detailAddress;
-    private String city;
-    private String district;
-    private String postalCode;
+    private String description;
 
     private int quantity;
     private int bathrooms;
@@ -23,13 +20,10 @@ public class PropertySnippetResponse {
 
     public static PropertySnippetResponse from(PropertySnippet snippet, PropertyAddress address) {
         return PropertySnippetResponse.builder()
-                .title(snippet.getTitle())
+                .complexName(snippet.getAptName())
                 .description(snippet.getDescription())
                 .streetAddress(address.getStreetAddress())
                 .detailAddress(address.getDetailAddress())
-                .city(address.getCity())
-                .district(address.getDistrict())
-                .postalCode(address.getPostalCode())
                 .quantity(snippet.getQuantity())
                 .bathrooms(snippet.getBathrooms())
                 .builtYear(snippet.getBuiltYear())

--- a/src/main/java/com/proppay/platform/pay/adapter/out/EstatePersistenceAdapter.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/out/EstatePersistenceAdapter.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -16,6 +17,12 @@ import java.util.Optional;
 public class EstatePersistenceAdapter implements LoadEstatePort {
 
     private final EstateMongoRepository repository;
+
+    @Override
+    public List<Estate> loadEstatesNearBy( double longitude, double latitude, double radiusInKm) {
+        return repository.findByLocation(longitude, latitude,radiusInKm)
+                .stream().map(EstateDocument::toDomain).toList();
+    }
 
     @Override
     public Optional<Estate> loadEstateByCode(String kaptCode) {

--- a/src/main/java/com/proppay/platform/pay/adapter/out/EstatePersistenceAdapter.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/out/EstatePersistenceAdapter.java
@@ -1,0 +1,38 @@
+package com.proppay.platform.pay.adapter.out;
+
+import com.proppay.platform.pay.adapter.out.mongo.estate.EstateDocument;
+import com.proppay.platform.pay.adapter.out.mongo.estate.EstateMongoRepository;
+import com.proppay.platform.pay.application.out.estate.LoadEstatePort;
+import com.proppay.platform.pay.domain.estate.Estate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class EstatePersistenceAdapter implements LoadEstatePort {
+
+    private final EstateMongoRepository repository;
+
+    @Override
+    public Optional<Estate> loadEstateByCode(String kaptCode) {
+        return repository.findByKaptCode(kaptCode)
+                .map(EstateDocument::toDomain);
+    }
+
+    @Override
+    public Optional<Estate> loadEstateByName(String kaptName) {
+        return repository.findByKaptName(kaptName)
+                .map(EstateDocument::toDomain);
+    }
+
+    @Override
+    public Page<Estate> loadEstatesByRegion(String region, Pageable pageable) {
+        return repository.findByKaptAddrContaining(region, pageable)
+                .map(EstateDocument::toDomain);
+    }
+
+}

--- a/src/main/java/com/proppay/platform/pay/adapter/out/PropertyPersistenceAdapter.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/out/PropertyPersistenceAdapter.java
@@ -2,19 +2,17 @@ package com.proppay.platform.pay.adapter.out;
 
 import com.proppay.platform.pay.adapter.out.jpa.property.PropertyJpaEntity;
 import com.proppay.platform.pay.adapter.out.jpa.property.PropertyJpaEntityRepository;
-import com.proppay.platform.pay.adapter.in.web.dto.ConditionRequest;
+import com.proppay.platform.pay.adapter.in.web.dto.PropertyConditionRequest;
 import com.proppay.platform.pay.application.out.property.DeletePropertyPort;
 import com.proppay.platform.pay.application.out.property.LoadPropertyPort;
 import com.proppay.platform.pay.application.out.property.SavePropertyPort;
 import com.proppay.platform.pay.domain.property.Property;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -37,24 +35,25 @@ public class PropertyPersistenceAdapter implements LoadPropertyPort, SavePropert
 
     @Override
     public Page<Property> loadList(Pageable pageable) {
-        Page<PropertyJpaEntity> result = repository.findAllByOrderByCreatedAtDesc(pageable);
-        return convertToPage(result, pageable);
+        return repository.findAllByOrderByCreatedAtDesc(pageable)
+                .map(PropertyJpaEntity::toDomain);
+
     }
 
     @Override
     public Page<Property> loadListByLikeCount(Pageable pageable) {
-        Page<PropertyJpaEntity> result = repository.findAllOrderByLikeCount(pageable);
-        return convertToPage(result, pageable);
+        return repository.findAllOrderByLikeCount(pageable)
+                .map(PropertyJpaEntity::toDomain);
     }
 
     @Override
     public Page<Property> loadListByViewCount(Pageable pageable) {
-        Page<PropertyJpaEntity> result = repository.findAllOrderByViewCount(pageable);
-        return convertToPage(result, pageable);
+        return repository.findAllOrderByViewCount(pageable)
+                .map(PropertyJpaEntity::toDomain);
     }
 
     @Override
-    public Page<Property> loadListByCondition(Pageable pageable, ConditionRequest request) {
+    public Page<Property> loadListByCondition(Pageable pageable, PropertyConditionRequest request) {
         return null;
     }
 
@@ -63,12 +62,4 @@ public class PropertyPersistenceAdapter implements LoadPropertyPort, SavePropert
         repository.deleteById(id);
     }
 
-    /**
-     * Page<PropertyJpaEntity>를 Page<Property>로 변환하는 공통 메서드
-     */
-
-    private Page<Property> convertToPage(Page<PropertyJpaEntity> result, Pageable pageable) {
-        List<Property> dtoList = result.map(PropertyJpaEntity::toDomain).getContent();
-        return new PageImpl<>(dtoList, pageable, result.getTotalElements());
-    }
 }

--- a/src/main/java/com/proppay/platform/pay/adapter/out/jpa/property/PropertyJpaEntity.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/out/jpa/property/PropertyJpaEntity.java
@@ -38,10 +38,14 @@ public class PropertyJpaEntity extends BaseEntity {
 
     private boolean verified;
 
+    // 기존 아파트와 연관되는 변수
+    private String kaptCode;
+
     // from
     public static PropertyJpaEntity from(Property property) {
         return PropertyJpaEntity.builder()
                 .type(property.getType())
+                .kaptCode(property.getKaptCode())
                 .address(PropertyAddressJpaEntity.from(property.getAddress()))
                 .owner(UserJpaEntity.from(property.getOwner()))
                 .snippet(PropertySnippetJpaEntity.from(property.getSnippet()))
@@ -56,6 +60,7 @@ public class PropertyJpaEntity extends BaseEntity {
         return Property.builder()
                 .id(id)
                 .type(type)
+                .kaptCode(kaptCode)
                 .address(address.toDomain())
                 .owner(owner.toDomain())
                 .snippet(snippet.toDomain())

--- a/src/main/java/com/proppay/platform/pay/adapter/out/jpa/property/PropertySnippetJpaEntity.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/out/jpa/property/PropertySnippetJpaEntity.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Embeddable
 public class PropertySnippetJpaEntity {
 
-    private String title;
+    private String aptName;
     private String description;
     private int quantity; // 방 개수
     private int bathrooms; // 욕실 개수 추가
@@ -22,7 +22,7 @@ public class PropertySnippetJpaEntity {
     // from
     public static PropertySnippetJpaEntity from(PropertySnippet snippet) {
         return PropertySnippetJpaEntity.builder()
-                .title(snippet.getTitle())
+                .aptName(snippet.getAptName())
                 .description(snippet.getDescription())
                 .quantity(snippet.getQuantity())
                 .bathrooms(snippet.getBathrooms())
@@ -33,7 +33,7 @@ public class PropertySnippetJpaEntity {
     // toDomain
     public PropertySnippet toDomain() {
         return PropertySnippet.builder()
-                .title(title)
+                .aptName(aptName)
                 .description(description)
                 .quantity(quantity)
                 .bathrooms(bathrooms)

--- a/src/main/java/com/proppay/platform/pay/adapter/out/mongo/estate/EstateDocument.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/out/mongo/estate/EstateDocument.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.index.GeoSpatialIndexType;
+import org.springframework.data.mongodb.core.index.GeoSpatialIndexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -30,6 +32,7 @@ public class EstateDocument {
     private String kaptMparea_85;
     private String kaptName;
 
+    @GeoSpatialIndexed(type = GeoSpatialIndexType.GEO_2DSPHERE)
     private Location location;
 
     private String convenientFacility;

--- a/src/main/java/com/proppay/platform/pay/adapter/out/mongo/estate/EstateDocument.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/out/mongo/estate/EstateDocument.java
@@ -1,0 +1,110 @@
+package com.proppay.platform.pay.adapter.out.mongo.estate;
+
+import com.proppay.platform.pay.domain.estate.Estate;
+import com.proppay.platform.pay.domain.estate.Location;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.util.Arrays;
+
+@Document(collection = "db")  // "db" 컬렉션을 사용하도록 설정
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class EstateDocument {
+
+    @Field("_id")
+    private String id;
+
+    private String kaptCode;
+    private String pricePerSquareMeter;
+    private String kaptAddr;
+    private String kaptMparea_136;
+    private String kaptMparea_135;
+    private String kaptMparea_60;
+    private String kaptMparea_85;
+    private String kaptName;
+
+    private Location location;
+
+    private String convenientFacility;
+    private String educationFacility;
+    private String kaptdPcnt;
+    private String kaptdPcntu;
+    private String kaptdWtimebus;
+    private String kaptdWtimesub;
+    private String subwayLine;
+    private String subwayStation;
+    private String welfareFacility;
+
+    public static EstateDocument from(Estate estate) {
+
+        Location location = Location.builder()
+                .type("Point")
+                .coordinates(Arrays.asList(
+                        estate.getLocation().getLongitude(),  // 경도
+                        estate.getLocation().getLatitude())   // 위도
+                )
+                .build();
+
+        return EstateDocument.builder()
+                .kaptCode(estate.getKaptCode())
+                .pricePerSquareMeter(estate.getPricePerSquareMeter())
+                .kaptAddr(estate.getKaptAddr())
+                .kaptMparea_135(estate.getKaptMparea_135())
+                .kaptMparea_136(estate.getKaptMparea_136())
+                .kaptMparea_60(estate.getKaptMparea_60())
+                .kaptMparea_85(estate.getKaptMparea_85())
+                .kaptName(estate.getKaptName())
+                .location(location)
+                .convenientFacility(estate.getConvenientFacility())
+                .educationFacility(estate.getEducationFacility())
+                .kaptdPcnt(estate.getKaptdPcnt())
+                .kaptdPcntu(estate.getKaptdPcntu())
+                .kaptdWtimebus(estate.getKaptdWtimebus())
+                .kaptdWtimesub(estate.getKaptdWtimesub())
+                .subwayLine(estate.getSubwayLine())
+                .subwayStation(estate.getSubwayStation())
+                .welfareFacility(estate.getWelfareFacility())
+                .build();
+    }
+
+    public Estate toDomain() {
+
+        Location location = Location.builder()
+                .type("Point")
+                .coordinates(Arrays.asList(
+                        this.getLocation().getLongitude(),  // 경도
+                        this.getLocation().getLatitude())   // 위도
+                )
+                .build();
+
+        return Estate.builder()
+                .id(this.id)
+                .kaptCode(this.kaptCode)
+                .pricePerSquareMeter(this.pricePerSquareMeter)
+                .kaptAddr(this.kaptAddr)
+                .kaptMparea_135(this.kaptMparea_135)
+                .kaptMparea_136(this.kaptMparea_136)
+                .kaptMparea_60(this.kaptMparea_60)
+                .kaptMparea_85(this.kaptMparea_85)
+                .kaptName(this.kaptName)
+                .location(location)
+                .convenientFacility(this.convenientFacility)
+                .educationFacility(this.educationFacility)
+                .kaptdPcnt(this.kaptdPcnt)
+                .kaptdPcntu(this.kaptdPcntu)
+                .kaptdWtimebus(this.kaptdWtimebus)
+                .kaptdWtimesub(this.kaptdWtimesub)
+                .subwayLine(this.subwayLine)
+                .subwayStation(this.subwayStation)
+                .welfareFacility(this.welfareFacility)
+                .build();
+    }
+
+}

--- a/src/main/java/com/proppay/platform/pay/adapter/out/mongo/estate/EstateMongoRepository.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/out/mongo/estate/EstateMongoRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 
-import java.util.Optional;
+import java.util.*;
 
 public interface EstateMongoRepository extends MongoRepository<EstateDocument, String> {
 
@@ -17,6 +17,10 @@ public interface EstateMongoRepository extends MongoRepository<EstateDocument, S
     // 특정 동이나 특정 지구를 포함하는 주소 검색 (예: "분당구", "야탑동")
     @Query("{'kaptAddr': { $regex: ?0, $options: 'i' }}")
     Page<EstateDocument> findByKaptAddrContaining(String address, Pageable pageable);
+
+    // 좌표 주변의 특정 반경이상 주소 검색
+    @Query(value = "{ 'location': { $geoWithin: { $centerSphere: [ [ ?0, ?1 ], ?2 ] } } }")
+    List<EstateDocument> findByLocation(double longitude, double latitude, double radiusInRadians);
 
 
 }

--- a/src/main/java/com/proppay/platform/pay/adapter/out/mongo/estate/EstateMongoRepository.java
+++ b/src/main/java/com/proppay/platform/pay/adapter/out/mongo/estate/EstateMongoRepository.java
@@ -1,0 +1,22 @@
+package com.proppay.platform.pay.adapter.out.mongo.estate;
+
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+
+import java.util.Optional;
+
+public interface EstateMongoRepository extends MongoRepository<EstateDocument, String> {
+
+    Optional<EstateDocument> findByKaptCode(String kaptCode);
+
+    Optional<EstateDocument> findByKaptName(String kaptName);
+
+    // 특정 동이나 특정 지구를 포함하는 주소 검색 (예: "분당구", "야탑동")
+    @Query("{'kaptAddr': { $regex: ?0, $options: 'i' }}")
+    Page<EstateDocument> findByKaptAddrContaining(String address, Pageable pageable);
+
+
+}

--- a/src/main/java/com/proppay/platform/pay/application/in/estate/GetEstateUseCase.java
+++ b/src/main/java/com/proppay/platform/pay/application/in/estate/GetEstateUseCase.java
@@ -1,0 +1,30 @@
+package com.proppay.platform.pay.application.in.estate;
+
+import com.proppay.platform.pay.domain.estate.Estate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface GetEstateUseCase {
+
+    /*
+        아파트 정보 가져오는 유즈케이스
+     */
+
+    // 특정 좌표 주변의 아파트 가져오기
+    List<Estate> loadEstatesNearBy(double latitude, double longitude, double radiusInKm);
+
+    // 코드를 바탕으로 아파트 가져오기
+    Optional<Estate> loadEstateByCode(String kaptCode);
+
+    // 이름을 바탕으로 아파트 가져오기
+    Optional<Estate> loadEstateByName(String kaptName);
+
+    // 특정 지역(동)을 포함하는 아파트 목록 페이징 조회
+    Page<Estate> loadEstatesByRegion(String region, Pageable pageable);
+
+
+
+}

--- a/src/main/java/com/proppay/platform/pay/application/in/property/ListPropertiesUseCase.java
+++ b/src/main/java/com/proppay/platform/pay/application/in/property/ListPropertiesUseCase.java
@@ -1,6 +1,6 @@
 package com.proppay.platform.pay.application.in.property;
 
-import com.proppay.platform.pay.adapter.in.web.dto.ConditionRequest;
+import com.proppay.platform.pay.adapter.in.web.dto.PropertyConditionRequest;
 import com.proppay.platform.pay.domain.property.Property;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,7 +15,7 @@ public interface ListPropertiesUseCase {
 
     Page<Property> getList(Pageable pageable);
 
-    Page<Property> getListByCondition(ConditionRequest request, Pageable pageable);
+    Page<Property> getListByCondition(PropertyConditionRequest request, Pageable pageable);
 
     Page<Property> getListByLikeCount(Pageable pageable);
 

--- a/src/main/java/com/proppay/platform/pay/application/out/estate/LoadEstatePort.java
+++ b/src/main/java/com/proppay/platform/pay/application/out/estate/LoadEstatePort.java
@@ -4,9 +4,12 @@ import com.proppay.platform.pay.domain.estate.Estate;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.*;
 import java.util.Optional;
 
 public interface LoadEstatePort {
+
+    List<Estate> loadEstatesNearBy( double longitude, double latitude, double radiusInKm);
 
     Optional<Estate> loadEstateByCode(String kaptCode);
 

--- a/src/main/java/com/proppay/platform/pay/application/out/estate/LoadEstatePort.java
+++ b/src/main/java/com/proppay/platform/pay/application/out/estate/LoadEstatePort.java
@@ -1,0 +1,19 @@
+package com.proppay.platform.pay.application.out.estate;
+
+import com.proppay.platform.pay.domain.estate.Estate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+public interface LoadEstatePort {
+
+    Optional<Estate> loadEstateByCode(String kaptCode);
+
+    Optional<Estate> loadEstateByName(String kaptName);
+
+    Page<Estate> loadEstatesByRegion(String region, Pageable pageable);
+
+
+
+}

--- a/src/main/java/com/proppay/platform/pay/application/out/property/LoadPropertyPort.java
+++ b/src/main/java/com/proppay/platform/pay/application/out/property/LoadPropertyPort.java
@@ -1,6 +1,6 @@
 package com.proppay.platform.pay.application.out.property;
 
-import com.proppay.platform.pay.adapter.in.web.dto.ConditionRequest;
+import com.proppay.platform.pay.adapter.in.web.dto.PropertyConditionRequest;
 import com.proppay.platform.pay.domain.property.Property;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -21,7 +21,7 @@ public interface LoadPropertyPort {
     Page<Property> loadListByViewCount(Pageable pageable);
 
     // 조건에 따른 정보 가져오기
-    Page<Property> loadListByCondition(Pageable pageable, ConditionRequest request);
+    Page<Property> loadListByCondition(Pageable pageable, PropertyConditionRequest request);
 
 
 }

--- a/src/main/java/com/proppay/platform/pay/application/service/EstateService.java
+++ b/src/main/java/com/proppay/platform/pay/application/service/EstateService.java
@@ -1,0 +1,40 @@
+package com.proppay.platform.pay.application.service;
+
+import com.proppay.platform.pay.application.in.estate.GetEstateUseCase;
+import com.proppay.platform.pay.application.out.estate.LoadEstatePort;
+import com.proppay.platform.pay.domain.estate.Estate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class EstateService implements GetEstateUseCase {
+
+    private final LoadEstatePort loadPort;
+
+    @Override
+    public List<Estate> loadEstatesNearBy(double latitude, double longitude, double radiusInKm) {
+        return List.of();
+    }
+
+    @Override
+    public Optional<Estate> loadEstateByCode(String kaptCode) {
+        return loadPort.loadEstateByCode(kaptCode);
+    }
+
+    @Override
+    public Optional<Estate> loadEstateByName(String kaptName) {
+        return loadPort.loadEstateByName(kaptName);
+    }
+
+    @Override
+    public Page<Estate> loadEstatesByRegion(String region, Pageable pageable) {
+        return loadPort.loadEstatesByRegion(region, pageable);
+    }
+
+}

--- a/src/main/java/com/proppay/platform/pay/application/service/EstateService.java
+++ b/src/main/java/com/proppay/platform/pay/application/service/EstateService.java
@@ -19,7 +19,8 @@ public class EstateService implements GetEstateUseCase {
 
     @Override
     public List<Estate> loadEstatesNearBy(double latitude, double longitude, double radiusInKm) {
-        return List.of();
+        double radiusInRadians = radiusInKm / 6378.1;  // 반경 km -> radians 변환
+        return loadPort.loadEstatesNearBy(latitude, longitude, radiusInRadians);
     }
 
     @Override

--- a/src/main/java/com/proppay/platform/pay/application/service/PropertyService.java
+++ b/src/main/java/com/proppay/platform/pay/application/service/PropertyService.java
@@ -1,48 +1,56 @@
 package com.proppay.platform.pay.application.service;
 
 
-import com.proppay.platform.pay.adapter.in.web.dto.ConditionRequest;
+import com.proppay.platform.pay.adapter.in.web.dto.PropertyConditionRequest;
 import com.proppay.platform.pay.adapter.in.web.dto.PropertyRequest;
 import com.proppay.platform.pay.application.in.property.*;
+import com.proppay.platform.pay.application.out.estate.LoadEstatePort;
 import com.proppay.platform.pay.application.out.property.DeletePropertyPort;
 import com.proppay.platform.pay.application.out.property.LoadPropertyPort;
 import com.proppay.platform.pay.application.out.user.LoadUserPort;
 import com.proppay.platform.pay.application.out.property.SavePropertyPort;
+import com.proppay.platform.pay.domain.estate.Estate;
 import com.proppay.platform.pay.domain.property.Property;
 import com.proppay.platform.pay.domain.property.PropertyAddress;
 import com.proppay.platform.pay.domain.property.PropertySnippet;
 import com.proppay.platform.pay.domain.property.PropertyStatistic;
 import com.proppay.platform.pay.domain.user.User;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.NoSuchElementException;
 import java.util.Optional;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
+@Transactional
+
 public class PropertyService implements CreatePropertyUseCase, GetPropertyDetailsUseCase ,DeletePropertyUseCase, UpdatePropertyUseCase, ListPropertiesUseCase {
 
     private final SavePropertyPort savePort;
     private final LoadPropertyPort loadPort;
     private final DeletePropertyPort deletePort;
     private final LoadUserPort loadUserPort;
+    private final LoadEstatePort loadEstatePort;
 
     @Override
     public Property create(PropertyRequest request) {
 
-        User user = loadUserPort.loadUser(request.getUserId())
-                .orElseThrow(() -> new NoSuchElementException("해당 유저가 존재하지 않습니다"));
 
-        PropertyAddress address = PropertyAddress.of(request.getStreetAddress(), request.getDetailAddress(), request.getPostalCode());
-        PropertySnippet snippet = PropertySnippet.of(request.getTitle(), request.getDescription(), request.getQuantity(), request.getBathrooms(), request.getBuiltYear());
+        User user = loadUserPort.loadUser(request.getUserId())
+                .orElseThrow(() -> new EntityNotFoundException("해당 유저가 존재하지 않습니다"));
+
+        Estate estate = loadEstatePort.loadEstateByCode(request.getAptCode())
+                .orElseThrow(() -> new EntityNotFoundException("해당하는 아파트가 존재하지 않습니다."));
+
+        PropertyAddress address = PropertyAddress.of(estate.getKaptAddr(), request.getDetailAddress(), request.getPostalCode());
+        PropertySnippet snippet = PropertySnippet.of(estate.getKaptName(), request.getDescription(), request.getQuantity(), request.getBathrooms(), request.getBuiltYear());
         PropertyStatistic statistic = PropertyStatistic.of(0, 0);
 
-        Property property = Property.of(user, request.getType(), address, snippet, statistic, request.getPrice());
+        Property property = Property.of(user, request.getType(), address, snippet, statistic, request.getPrice(), request.getAptCode());
 
         return savePort.saveProperty(property);
     }
@@ -63,7 +71,7 @@ public class PropertyService implements CreatePropertyUseCase, GetPropertyDetail
     }
 
     @Override
-    public Page<Property> getListByCondition(ConditionRequest request, Pageable pageable) {
+    public Page<Property> getListByCondition(PropertyConditionRequest request, Pageable pageable) {
         return loadPort.loadListByCondition(pageable, request);
     }
 

--- a/src/main/java/com/proppay/platform/pay/domain/estate/Estate.java
+++ b/src/main/java/com/proppay/platform/pay/domain/estate/Estate.java
@@ -1,0 +1,36 @@
+package com.proppay.platform.pay.domain.estate;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class Estate {
+
+    private String id;
+    private String kaptCode;
+    private String pricePerSquareMeter;
+    private String kaptAddr;
+    private String kaptMparea_135;
+    private String kaptMparea_136;
+    private String kaptMparea_60;
+    private String kaptMparea_85;
+    private String kaptName;
+
+    private Location location;
+    private String convenientFacility;
+    private String educationFacility;
+    private String kaptdPcnt;
+    private String kaptdPcntu;
+    private String kaptdWtimebus;
+    private String kaptdWtimesub;
+    private String subwayLine;
+    private String subwayStation;
+    private String welfareFacility;
+
+
+}

--- a/src/main/java/com/proppay/platform/pay/domain/estate/Location.java
+++ b/src/main/java/com/proppay/platform/pay/domain/estate/Location.java
@@ -1,0 +1,25 @@
+package com.proppay.platform.pay.domain.estate;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+public class Location {
+    private String type;
+    private List<Double> coordinates;
+
+    public Double getLongitude() {
+        return coordinates.get(0);
+    }
+
+    public Double getLatitude() {
+        return coordinates.get(1);
+    }
+}

--- a/src/main/java/com/proppay/platform/pay/domain/property/Property.java
+++ b/src/main/java/com/proppay/platform/pay/domain/property/Property.java
@@ -24,10 +24,14 @@ public class Property extends BaseDomain {
     private long price;
     private boolean verified;
 
+    // 기존 아파트와 연관되는 변수
+    private String kaptCode;
+
     // 생성자
-    public static Property of(User user, PropertyType type, PropertyAddress address, PropertySnippet snippet, PropertyStatistic statistic, long price) {
+    public static Property of(User user, PropertyType type, PropertyAddress address, PropertySnippet snippet, PropertyStatistic statistic, long price, String kaptCode) {
         return Property.builder()
                 .owner(user)
+                .kaptCode(kaptCode)
                 .type(type)
                 .address(address)
                 .snippet(snippet)

--- a/src/main/java/com/proppay/platform/pay/domain/property/PropertySnippet.java
+++ b/src/main/java/com/proppay/platform/pay/domain/property/PropertySnippet.java
@@ -11,17 +11,17 @@ import lombok.NoArgsConstructor;
 @Getter
 public class PropertySnippet {
 
-    private String title;
+    private String aptName;
     private String description;
     private int quantity; // 방 개수
     private int bathrooms; // 욕실 개수 추가
     private int builtYear; // 건축 연도 추가
 
     // 생성자
-    public static PropertySnippet of(String title, String description, int quantity,
+    public static PropertySnippet of(String aptName, String description, int quantity,
                                      int bathrooms, int builtYear) {
         return PropertySnippet.builder()
-                .title(title)
+                .aptName(aptName)
                 .description(description)
                 .quantity(quantity)
                 .bathrooms(bathrooms)


### PR DESCRIPTION
## PR 제목
Estate 관련 정보 조회 서비스 추가

## 핵심 내용
MongoDB 기반 아파트 정보 조회 서비스 구현 및 매물 생성 로직 개선

## 세부 내용
- 아파트 조회 기능 추가
- 특정 좌표(위도/경도) 기준으로 주변 아파트 조회
- 코드 기반으로 아파트 정보 검색
- 아파트 이름을 이용한 조회 기능 제공
- 특정 지역(동)을 포함하는 아파트 목록을 페이징 처리하여 조회
- 매물 생성 로직 개선
- 매물 생성 시 Estate 데이터를 기반으로 등록하도록 변경
- 아파트 정보가 없는 경우 예외 처리 추가

## 기타 개선 사항
- 관련 엔티티 및 DTO 정리
